### PR TITLE
Added: Ability to define custom callbacks for tabs to include your own custom content outside of the framework.

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ This library collects and stores certain data on your server to ensure proper fu
 
 ## Changelog
 
+### 3.1.0
+Added: Ability to define custom callbacks for tabs to include your own custom content outside of the framework.
+
 ### 3.0.0
 * Added: Subsections
 * Added: Templating

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ This library collects and stores certain data on your server to ensure proper fu
 ## Changelog
 
 ### 3.1.0
-Added: Ability to define custom callbacks for tabs to include your own custom content outside of the framework.
+Added: Ability to define custom [callbacks](https://www.polyplugins.com/docs/settings-class-for-wordpress/fields/sections/#callbacks) for tabs to include your own custom content outside of the framework.
 
 ### 3.0.0
 * Added: Subsections

--- a/src/templates/default/index.php
+++ b/src/templates/default/index.php
@@ -90,10 +90,16 @@ if (!defined('ABSPATH')) exit;
               <?php echo esc_html(ucfirst($section)) . ' Settings'; ?>
             </h2>
             <div class="fields">
-              <?php foreach($fields as $field) : ?>
-                <?php $field['section'] = $section; ?>
-                <?php $this->add_field($field); ?>
-              <?php endforeach; ?>
+              <?php if (isset($section_data['callback']) && is_callable($section_data['callback'])) : ?>
+                <div class="field-container">
+                  <?php call_user_func($section_data['callback'], $section, $section_data, $this->settings); ?>
+                </div>
+              <?php else :?>
+                <?php foreach($fields as $field) : ?>
+                  <?php $field['section'] = $section; ?>
+                  <?php $this->add_field($field); ?>
+                <?php endforeach; ?>
+              <?php endif; ?>
             </div>
           </div>
         </div>
@@ -117,10 +123,16 @@ if (!defined('ABSPATH')) exit;
                   <?php echo esc_html($subsection['label'] ?? ucfirst($sub_id)) . ' Settings'; ?>
                 </h2>
                 <div class="fields">
-                  <?php foreach($sub_fields as $field) : ?>
-                    <?php $field['section'] = $section . '-' . $sub_id; ?>
-                    <?php $this->add_field($field); ?>
-                  <?php endforeach; ?>
+                  <?php if (isset($section_data['callback']) && is_callable($section_data['callback'])) : ?>
+                    <div class="field-container">
+                      <?php call_user_func($section_data['callback'], $section, $section_data, $this->settings); ?>
+                    </div>
+                  <?php else :?>
+                    <?php foreach($sub_fields as $field) : ?>
+                      <?php $field['section'] = $section . '-' . $sub_id; ?>
+                      <?php $this->add_field($field); ?>
+                    <?php endforeach; ?>
+                  <?php endif; ?>
                 </div>
               </div>
             </div>

--- a/src/templates/recharge/index.php
+++ b/src/templates/recharge/index.php
@@ -86,10 +86,16 @@ if (!defined('ABSPATH')) exit;
           <?php endif; ?>
           <div class="options-padding">
             <div class="fields">
-              <?php foreach($fields as $field) : ?>
-                <?php $field['section'] = $section; ?>
-                <?php $this->add_field($field); ?>
-              <?php endforeach; ?>
+              <?php if (isset($section_data['callback']) && is_callable($section_data['callback'])) : ?>
+                <div class="field-container">
+                  <?php call_user_func($section_data['callback'], $section, $section_data, $this->settings); ?>
+                </div>
+              <?php else :?>
+                <?php foreach($fields as $field) : ?>
+                  <?php $field['section'] = $section; ?>
+                  <?php $this->add_field($field); ?>
+                <?php endforeach; ?>
+              <?php endif; ?>
             </div>
           </div>
         </div>
@@ -107,10 +113,16 @@ if (!defined('ABSPATH')) exit;
               <?php endif; ?>
               <div class="options-padding">
                 <div class="fields">
-                  <?php foreach($sub_fields as $field) : ?>
-                    <?php $field['section'] = $section . '-' . $sub_id; ?>
-                    <?php $this->add_field($field); ?>
-                  <?php endforeach; ?>
+                  <?php if (isset($section_data['callback']) && is_callable($section_data['callback'])) : ?>
+                    <div class="field-container">
+                      <?php call_user_func($section_data['callback'], $section, $section_data, $this->settings); ?>
+                    </div>
+                  <?php else :?>
+                    <?php foreach($sub_fields as $field) : ?>
+                      <?php $field['section'] = $section . '-' . $sub_id; ?>
+                      <?php $this->add_field($field); ?>
+                    <?php endforeach; ?>
+                  <?php endif; ?>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Sometimes you may want to display custom data, dashboards, ect. Defining callbacks will allow you to break out of the framework.
[Learn More](https://www.polyplugins.com/docs/settings-class-for-wordpress/fields/sections/#callbacks)